### PR TITLE
refactor!: Improve configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,7 @@ import { SlackModule } from 'nestjs-slack';
   imports: [
     SlackModule.forRoot({
       type: 'api',
-      apiOptions: {
-        token: '<insert-token-here',
-      },
+      token: '<insert-token-here>',
     }),
   ],
 })
@@ -72,9 +70,7 @@ To use `webhook` type, you'll typically use these settings:
 ```typescript
 SlackModule.forRoot({
   type: 'webhook',
-  webhookOptions: {
-    url: '<the webhook url>',
-  },
+  url: '<the webhook url>',
 }),
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ and reusable Slack code declaratively and ready for production.
 
 [nestjs]: https://github.com/nestjs/nest
 
+This documentation is for v2 of this library. If you are looking for v1 documentation,
+please check the [v1] branch.
+
+[v1]: https://github.com/bjerkio/nestjs-slack/tree/v1
+
 ### :zap: &nbsp; Features
 
 - Used in many production workloads.

--- a/docs/migrate-v1-v2.md
+++ b/docs/migrate-v1-v2.md
@@ -1,0 +1,25 @@
+# Migrate from v1 to v2
+
+We've simplified configuration, essentially flattened the options.
+
+Before:
+
+```typescript
+SlackModule.forRoot({
+  type: 'webhook',
+  webhookOptions: {
+    url: '<the webhook url>',
+  },
+}),
+```
+
+After:
+
+```typescript
+SlackModule.forRoot({
+  type: 'webhook',
+  url: '<the webhook url>',
+}),
+```
+
+This is also is true for `apiOptions`. The values are still the same.

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -11,7 +11,7 @@ describe('api', () => {
     const app = await createApp({
       type: 'api',
       defaultChannel: 'my-channel',
-      apiOptions: { token: 'my-token' },
+      token: 'my-token',
     });
     service = app.get<SlackService>(SlackService);
   });

--- a/src/__tests__/google.test.ts
+++ b/src/__tests__/google.test.ts
@@ -1,4 +1,4 @@
-import { Log, LogSync } from '@google-cloud/logging';
+import { LogSync } from '@google-cloud/logging';
 import { Test } from '@nestjs/testing';
 import {
   GOOGLE_LOGGING,

--- a/src/__tests__/module.test.ts
+++ b/src/__tests__/module.test.ts
@@ -19,7 +19,7 @@ describe('slack.module', () => {
           useFactory: () => {
             return {
               type: 'webhook',
-              webhookOptions: { url: `${baseUrl}/webhook` },
+              url: `${baseUrl}/webhook`,
             };
           },
         }),
@@ -44,7 +44,7 @@ describe('slack.module', () => {
       slackConfigModuleOptions(): SlackConfig {
         return {
           type: 'webhook',
-          webhookOptions: { url: `${baseUrl}/webhook` },
+          url: `${baseUrl}/webhook`,
         };
       }
     }

--- a/src/__tests__/webhook.test.ts
+++ b/src/__tests__/webhook.test.ts
@@ -12,7 +12,7 @@ describe('webhook', () => {
     output = jest.fn();
     const app = await createApp({
       type: 'webhook',
-      webhookOptions: { url: `${baseUrl}/webhook` },
+      url: `${baseUrl}/webhook`,
     });
     service = app.get<SlackService>(SlackService);
   });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,3 +1,5 @@
 export * from './constants';
 export * from './slack.module';
 export * from './slack.service';
+
+export type Channels = string;

--- a/src/slack.module.ts
+++ b/src/slack.module.ts
@@ -120,16 +120,8 @@ export class SlackModule {
           };
         }
 
-        invariant(
-          opts.apiOptions,
-          'You must provide `apiOptions` when using the api type.',
-        );
-
         const { WebClient } = await import('@slack/web-api');
-        return new WebClient(
-          opts.apiOptions.token,
-          opts.apiOptions.clientOptions,
-        );
+        return new WebClient(opts.token, opts.clientOptions);
       },
     };
   }
@@ -146,12 +138,7 @@ export class SlackModule {
           };
         }
 
-        invariant(
-          opts.webhookOptions,
-          'You must provide `webhookOptions` when using the webhook type.',
-        );
-
-        return opts.webhookOptions.url;
+        return opts.url;
       },
     };
   }

--- a/src/slack.service.ts
+++ b/src/slack.service.ts
@@ -1,7 +1,7 @@
 import type { LogSync } from '@google-cloud/logging';
-import axios, { AxiosError } from 'axios';
 import { Inject, Injectable } from '@nestjs/common';
 import type { ChatPostMessageArguments, WebClient } from '@slack/web-api';
+import axios, { AxiosError } from 'axios';
 import type { SlackBlockDto } from 'slack-block-builder';
 import {
   GOOGLE_LOGGING,
@@ -9,7 +9,7 @@ import {
   SLACK_WEBHOOK_URL,
   SLACK_WEB_CLIENT,
 } from './constants';
-import type { SlackConfig, SlackRequestType } from './types';
+import type { SlackConfig } from './types';
 import { invariant } from './utils';
 
 export type SlackMessageOptions = Partial<ChatPostMessageArguments>;
@@ -106,12 +106,14 @@ export class SlackService {
    * @param opts
    */
   async postMessage(req: SlackMessageOptions): Promise<void> {
-    const requestTypes: Record<SlackRequestType, () => Promise<void>> = {
+    const requestTypes = {
       api: async () => this.runApiRequest(req),
       webhook: async () => this.runWebhookRequest(req),
       stdout: async () => this.runStdoutRequest(req),
       google: async () => this.runGoogleLoggingRequest(req),
     };
+
+    invariant(requestTypes[this.options.type], 'expected option to exist');
 
     await requestTypes[this.options.type]();
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,16 +2,26 @@ import { ModuleMetadata, Type } from '@nestjs/common';
 import { WebClientOptions } from '@slack/web-api';
 
 export interface SlackApiOptions {
+  type: 'api';
+
   /**
    * You'll need a token to authenticate with Slack Web API
    * Read more: https://api.slack.com/tutorials/tracks/getting-a-token
    */
   token: string;
 
+  /**
+   * This option is used when channel isn't defined
+   * when sending a request.
+   */
+  defaultChannel?: string;
+
   clientOptions?: WebClientOptions;
 }
 
 export interface SlackWebhookOptions {
+  type: 'webhook';
+
   /**
    * Incoming Webhooks are a simple way to post messages from apps into Slack.
    * Creating an Incoming Webhook gives you a unique URL to which you send a
@@ -22,57 +32,35 @@ export interface SlackWebhookOptions {
   url: string;
 }
 
-export type SlackRequestType = 'api' | 'webhook' | 'stdout' | 'google';
+export interface SlackStdoutOptions {
+  type: 'stdout';
 
-export interface SlackConfig {
   /**
-   * This argument refers to how you want to send requests
-   * to Slack.
-   *
-   * `api` is the default option, it utilizes `@slack/web-api`, which also
-   * requires setting `apiOptions`. Setting `stdout` and `google` makes
-   * this module send requests directly to stdout as a JSON-string. This is
-   * useful where you're consuming logs and want to forward them to Slack.
-   * `google` provides a JSON structure as Google Logging wants.
-   *
-   * **Note**: We suggest using a distributed model where logs are consumed
-   * when logging to Slack in production; it's easier to dump something to
-   * to a logger than calling the Slack Web API.
-   *
-   * @default stdout
+   * Setting this changes which function is used to stdout.
    */
-  type: SlackRequestType;
+  output?: (out: unknown) => void;
+}
+
+export interface SlackGoogleOptions {
+  type: 'google';
 
   /**
    * This option is used when channel isn't defined
    * when sending a request.
    */
   defaultChannel?: string;
-
-  /**
-   * These configuration options are only required when type is set to
-   * `api`.
-   */
-  apiOptions?: SlackApiOptions;
-
-  /**
-   * These configuration options are only required when type is set to
-   * `api`.
-   */
-  webhookOptions?: SlackWebhookOptions;
-
-  /**
-   * Setting this changes which function is used to stdout.
-   *
-   * Only used for types `stdout`
-   */
-  output?: (out: unknown) => void;
 }
 
-export interface SlackSyncConfig extends SlackConfig {
+export type SlackConfig =
+  | SlackApiOptions
+  | SlackWebhookOptions
+  | SlackStdoutOptions
+  | SlackGoogleOptions;
+
+export type SlackSyncConfig = SlackConfig & {
   // If true, registers `SlackModule` as a global module.
   isGlobal?: boolean;
-}
+};
 
 export interface SlackAsyncConfig extends Pick<ModuleMetadata, 'imports'> {
   useClass?: Type<SlackConfigFactory>;


### PR DESCRIPTION
Removes the need for `webhookOptions`, and `apiOptions` as separate fields. This should improve developer experience.

BREAKING CHANGE: To migrate to this, you need to remove `apiOptions` or `webhookOptions`. Read more at docs/migrate-v1-v2.md
