### PR TITLE
feat(public_webclient) allows Slack WebClient to be used externally

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,22 @@ export class AuthService {
 }
 ```
 
+The underlying Slack `WebClient` is also available to use on the `SlackService`:
+
+```typescript
+import { Injectable } from '@nestjs/common';
+import { SlackService } from 'nestjs-slack';
+
+@Injectable()
+export class AuthService {
+  constructor(private service: SlackService) {}
+
+  otherSlackWebClientMethod(email) {
+    return await this.service.client.users.lookupByEmail(email)
+  }
+}
+```
+
 ### Use with Google Logging
 
 ```shell

--- a/src/__tests__/slack.service.test.ts
+++ b/src/__tests__/slack.service.test.ts
@@ -1,6 +1,7 @@
-import { SlackService } from '../slack.service';
+import { WebClient } from '@slack/web-api';
 import { BlockCollection, Blocks } from 'slack-block-builder';
 import { createApp } from './fixtures';
+import { SlackService } from '../slack.service';
 
 describe('SlackService', () => {
   it('must be defined', async () => {
@@ -29,6 +30,12 @@ describe('SlackService', () => {
         const blocks = BlockCollection(Blocks.Section({ text: 'hello-world' }));
         await service.sendBlocks(blocks);
         expect(service.postMessage).toHaveBeenCalledWith({ blocks });
+      });
+    });
+
+    describe('WebClient', () => {
+      it('slack sdk WebClient is available', async () => {
+        expect(service.client).toBeDefined();
       });
     });
   });

--- a/src/slack.service.ts
+++ b/src/slack.service.ts
@@ -20,7 +20,7 @@ export type SlackMessageOptions<C = Channels> = Partial<
 export class SlackService<C = Channels> {
   constructor(
     @Inject(SLACK_MODULE_OPTIONS) private readonly options: SlackConfig,
-    @Inject(SLACK_WEB_CLIENT) private readonly client: WebClient | null,
+    @Inject(SLACK_WEB_CLIENT) public readonly client: WebClient | null,
     @Inject(GOOGLE_LOGGING) private readonly log: LogSync | null,
   ) {}
 


### PR DESCRIPTION
Now users can also use the Slack API directly from on the `SlackService`